### PR TITLE
Small windows fixes other way to init 

### DIFF
--- a/lua/buffish/display.lua
+++ b/lua/buffish/display.lua
@@ -16,33 +16,33 @@ local M = {
 
     for i, buffer in ipairs(handles) do
       -- if not api.nvim_buf_is_valid(buffer.bufnr) then break end
-	  if buffer and buffer.display_name then
-		session.buf_index[i] = buffer.bufnr
+      if buffer and buffer.display_name then
+        session.buf_index[i] = buffer.bufnr
 
-	    api.nvim_buf_set_lines(bufnr, i - 1, i, false, {buffer.name})
+        api.nvim_buf_set_lines(bufnr, i - 1, i, false, { buffer.name })
 
-	    local filename = vim.fn.fnamemodify(buffer.display_name, ":t")
+        local filename = vim.fn.fnamemodify(buffer.display_name, ":t")
 
-	    api.nvim_buf_set_extmark(bufnr, ns, i - 1, 0, {
-			sign_text = string.format("%2i", buffer.bufnr),
-			end_col = #buffer.name - #buffer.display_name,
-			hl_group = "Normal",
-			conceal = " "
-		})
+        api.nvim_buf_set_extmark(bufnr, ns, i - 1, 0, {
+          sign_text = string.format("%2i", buffer.bufnr),
+          end_col = #buffer.name - #buffer.display_name,
+          hl_group = "Normal",
+          conceal = " "
+        })
 
-		api.nvim_buf_set_extmark(bufnr, ns, i - 1,
-								   #buffer.name - #buffer.display_name, {
-			hl_group = "Directory",
-			end_col = #buffer.name - #filename
-		})
+        api.nvim_buf_set_extmark(bufnr, ns, i - 1,
+          #buffer.name - #buffer.display_name, {
+            hl_group = "Directory",
+            end_col = #buffer.name - #filename
+          })
 
-		api.nvim_buf_set_extmark(bufnr, ns, i - 1, #buffer.name - #filename, {
-			hl_group = "Identifier",
-			end_col = #buffer.name
-		})
-	  end
+        api.nvim_buf_set_extmark(bufnr, ns, i - 1, #buffer.name - #filename, {
+          hl_group = "Identifier",
+          end_col = #buffer.name
+        })
+      end
     end
-	
+
     api.nvim_buf_set_option(bufnr, 'modified', false)
     api.nvim_buf_set_option(bufnr, 'modifiable', false)
   end,

--- a/lua/buffish/display.lua
+++ b/lua/buffish/display.lua
@@ -16,31 +16,33 @@ local M = {
 
     for i, buffer in ipairs(handles) do
       -- if not api.nvim_buf_is_valid(buffer.bufnr) then break end
-      session.buf_index[i] = buffer.bufnr
+	  if buffer and buffer.display_name then
+		session.buf_index[i] = buffer.bufnr
 
-      api.nvim_buf_set_lines(bufnr, i - 1, i, false, {buffer.name})
+	    api.nvim_buf_set_lines(bufnr, i - 1, i, false, {buffer.name})
 
-      local filename = vim.fn.fnamemodify(buffer.display_name, ":t")
+	    local filename = vim.fn.fnamemodify(buffer.display_name, ":t")
 
-      api.nvim_buf_set_extmark(bufnr, ns, i - 1, 0, {
-        sign_text = string.format("%2i", buffer.bufnr),
-        end_col = #buffer.name - #buffer.display_name,
-        hl_group = "Normal",
-        conceal = " "
-      })
+	    api.nvim_buf_set_extmark(bufnr, ns, i - 1, 0, {
+			sign_text = string.format("%2i", buffer.bufnr),
+			end_col = #buffer.name - #buffer.display_name,
+			hl_group = "Normal",
+			conceal = " "
+		})
 
-      api.nvim_buf_set_extmark(bufnr, ns, i - 1,
-                               #buffer.name - #buffer.display_name, {
-        hl_group = "Directory",
-        end_col = #buffer.name - #filename
-      })
+		api.nvim_buf_set_extmark(bufnr, ns, i - 1,
+								   #buffer.name - #buffer.display_name, {
+			hl_group = "Directory",
+			end_col = #buffer.name - #filename
+		})
 
-      api.nvim_buf_set_extmark(bufnr, ns, i - 1, #buffer.name - #filename, {
-        hl_group = "Identifier",
-        end_col = #buffer.name
-      })
+		api.nvim_buf_set_extmark(bufnr, ns, i - 1, #buffer.name - #filename, {
+			hl_group = "Identifier",
+			end_col = #buffer.name
+		})
+	  end
     end
-
+	
     api.nvim_buf_set_option(bufnr, 'modified', false)
     api.nvim_buf_set_option(bufnr, 'modifiable', false)
   end,

--- a/lua/buffish/display.lua
+++ b/lua/buffish/display.lua
@@ -24,7 +24,7 @@ local M = {
         local filename = vim.fn.fnamemodify(buffer.display_name, ":t")
 
         api.nvim_buf_set_extmark(bufnr, ns, i - 1, 0, {
-          sign_text = string.format("%2i", buffer.bufnr),
+          sign_text = string.format("%2i", i),
           end_col = #buffer.name - #buffer.display_name,
           hl_group = "Normal",
           conceal = " "

--- a/lua/buffish/display.lua
+++ b/lua/buffish/display.lua
@@ -16,7 +16,7 @@ local M = {
 
     for i, buffer in ipairs(handles) do
       -- if not api.nvim_buf_is_valid(buffer.bufnr) then break end
-      if buffer and buffer.display_name then
+      if buffer and buffer.display_name and buffer.bufnr then
         session.buf_index[i] = buffer.bufnr
 
         api.nvim_buf_set_lines(bufnr, i - 1, i, false, { buffer.name })
@@ -24,7 +24,7 @@ local M = {
         local filename = vim.fn.fnamemodify(buffer.display_name, ":t")
 
         api.nvim_buf_set_extmark(bufnr, ns, i - 1, 0, {
-          sign_text = string.format("%4i", buffer.bufnr),
+          sign_text = string.format("%2i", buffer.bufnr),
           end_col = #buffer.name - #buffer.display_name,
           hl_group = "Normal",
           conceal = " "

--- a/lua/buffish/display.lua
+++ b/lua/buffish/display.lua
@@ -24,7 +24,7 @@ local M = {
         local filename = vim.fn.fnamemodify(buffer.display_name, ":t")
 
         api.nvim_buf_set_extmark(bufnr, ns, i - 1, 0, {
-          sign_text = string.format("%2i", buffer.bufnr),
+          sign_text = string.format("%4i", buffer.bufnr),
           end_col = #buffer.name - #buffer.display_name,
           hl_group = "Normal",
           conceal = " "

--- a/lua/buffish/handles.lua
+++ b/lua/buffish/handles.lua
@@ -7,7 +7,7 @@ end
 local extract_filename = function(name, depth)
   -- replace \ with / for windows paths..
   if package.config:sub(1,1) == '\\' then
-	  name = name:gsub("\\", "/")
+    name = name:gsub("\\", "/")
   end
   local parts = vim.split(name, "/", {plain = true, trimempty = true})
 
@@ -58,10 +58,10 @@ return {
 
     for name, bufl in pairs(names) do
       for _, bufi in ipairs(bufl) do 
-	    if handles[bufi] then
-		  handles[bufi].display_name = name
-		end
-	  end
+        if handles[bufi] then
+          handles[bufi].display_name = name
+        end
+      end
     end
 
     table.sort(handles, function(a, b)

--- a/lua/buffish/handles.lua
+++ b/lua/buffish/handles.lua
@@ -5,6 +5,10 @@ local safely_insert = function(list, entry)
 end
 
 local extract_filename = function(name, depth)
+  -- replace \ with / for windows paths..
+  if package.config:sub(1,1) == '\\' then
+	  name = name:gsub("\\", "/")
+  end
   local parts = vim.split(name, "/", {plain = true, trimempty = true})
 
   local filename = string.format(string.rep("%s", depth + 1, "/"),

--- a/lua/buffish/handles.lua
+++ b/lua/buffish/handles.lua
@@ -57,7 +57,11 @@ return {
     names = disambiguate(handles, names, 1)
 
     for name, bufl in pairs(names) do
-      for _, bufi in ipairs(bufl) do handles[bufi].display_name = name end
+      for _, bufi in ipairs(bufl) do 
+	    if handles[bufi] then
+		  handles[bufi].display_name = name
+		end
+	  end
     end
 
     table.sort(handles, function(a, b)

--- a/plugin/buffish.vim
+++ b/plugin/buffish.vim
@@ -18,6 +18,8 @@ let g:loaded_buffish = 1
 " Lua modules from the plugin's dependency directory.
 " let s:lua_rocks_deps_loc =  expand("<sfile>:h:r") . "/../lua/buffish/deps"
 " exe "lua package.path = package.path .. ';" . s:lua_rocks_deps_loc . "/lua-?/init.lua'"
+
+" initialize with lua instead of above string concatenation
 lua require('buffish.init')
 
 " Exposes the plugin's functions for use as commands in Neovim.

--- a/plugin/buffish.vim
+++ b/plugin/buffish.vim
@@ -16,8 +16,9 @@ let g:loaded_buffish = 1
 
 " Defines a package path for Lua. This facilitates importing the
 " Lua modules from the plugin's dependency directory.
-let s:lua_rocks_deps_loc =  expand("<sfile>:h:r") . "/../lua/buffish/deps"
-exe "lua package.path = package.path .. ';" . s:lua_rocks_deps_loc . "/lua-?/init.lua'"
+" let s:lua_rocks_deps_loc =  expand("<sfile>:h:r") . "/../lua/buffish/deps"
+" exe "lua package.path = package.path .. ';" . s:lua_rocks_deps_loc . "/lua-?/init.lua'"
+lua require('buffish.init')
 
 " Exposes the plugin's functions for use as commands in Neovim.
 command! -nargs=0 Buffish lua require("buffish").open()


### PR DESCRIPTION
Because the initialization relied on string concatenation the c:\xxx broke because it expected \x as escape character here.
issue: #1 mentions this
I don't know if this works on linux/mac so you should check that.

The other thing I added is on windows in the `extract_filename` I first replace \\ to / to make it work.

Thanks for your work it is a simple handy plugin I like to use.